### PR TITLE
Kconfig采用rsource相对路径方式

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -1,0 +1,10 @@
+config TARGET_FILE
+    string
+    default ""
+
+config HOSTOS
+    string
+    option env="HOSTOS"
+    default "Linux"
+    
+rsource "$HOSTOS/Kconfig"

--- a/Linux/Kconfig
+++ b/Linux/Kconfig
@@ -1,3 +1,1 @@
-source "$PKGS_DIR/sdk/$HOSTOS/arm-none-eabi-gcc/Kconfig"
-source "$PKGS_DIR/sdk/$HOSTOS/aarch64-none-elf-gcc/Kconfig"
-source "$PKGS_DIR/sdk/$HOSTOS/riscv-none-elf-gcc/Kconfig"
+rsource "*/Kconfig"

--- a/Windows/Kconfig
+++ b/Windows/Kconfig
@@ -1,3 +1,1 @@
-source "$PKGS_DIR/sdk/$HOSTOS/arm-none-eabi-gcc/Kconfig"
-source "$PKGS_DIR/sdk/$HOSTOS/aarch64-none-elf-gcc/Kconfig"
-source "$PKGS_DIR/sdk/$HOSTOS/riscv-none-elf-gcc/Kconfig"
+rsouce "*/Kconfig"


### PR DESCRIPTION
由于sdk是新增的功能，不需要考虑兼容老版本的menuconfig，因此将Kconfig修改成相对路径的书写格式